### PR TITLE
Change versioning system

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ TNT should only be used for relatively small worlds.
 
 ### ⚠ TNT is experimental and is not backwards compatible. Your worlds will break when TNT or Minecraft updates. It is highly recommended to keep your original worlds.
 
+## Upgrading to a new major version
+A major version change (e.g. v1.2.3 -> v2.0.0) indicates there is an incompatible breaking change in TNT.
+This may require re-converting your world or other manual actions.
+
 ## Cool stuff
 - Very fast loading times (23ms for my lobby - idk what Anvil is)
 - Small file size (~80kb in TNT vs ~13mb in Anvil for my lobby)


### PR DESCRIPTION
Since TNT versions aren't Minestom/MC version specific, change the versioning format to regular semantic versioning.

We should bump the major version each time we make a breaking change to the TNT format, users are responsible for re-generating their world when there is a new MC version.